### PR TITLE
Remove unused ContactCard props

### DIFF
--- a/src/components/AppUI.tsx
+++ b/src/components/AppUI.tsx
@@ -68,12 +68,8 @@ export default function AppUI({ children }: { children: ReactNode }): JSX.Elemen
       <footer className={styles.footer}>
         <ContactCard
           name={"Bhima Raj Bhattarai"}
-          nickname={"BRB"}
-          email={"bhima@bhattarai.com.au"}
-          phoneNumber={61461461461}
           genre={"Modern Electronic Music"}
           location={"Sydney, Australia"}
-          tagline={"Just gimme a sec..."}
           tiktok={"tiktokuser"}
           discord={"discorduser"}
           youtube={"youtubeuser"}

--- a/src/components/ContactCard.tsx
+++ b/src/components/ContactCard.tsx
@@ -7,12 +7,8 @@ import { faTiktok, faDiscord, faYoutube } from "@fortawesome/free-brands-svg-ico
 
 interface ContactCardProps {
     name: string;
-    nickname: string;
-    email: string;
-    phoneNumber: number;
     genre: string;
     location: string;
-    tagline: string;
     tiktok: string;
     discord: string;
     youtube: string;


### PR DESCRIPTION
### Motivation
- Remove unused properties from `ContactCardProps` so the component interface matches the actual rendered JSX.
- Simplify the footer usage by dropping unnecessary contact fields passed into `ContactCard`.
- Reduce the component surface area and prevent stale or misleading props from being carried around.

### Description
- Removed `nickname`, `email`, `phoneNumber`, and `tagline` from `src/components/ContactCard.tsx`'s `ContactCardProps`.
- Updated the `ContactCard` parameter list to `({ name, genre, location, tiktok, discord, youtube }: ContactCardProps)`.
- Updated `src/components/AppUI.tsx` to stop passing the removed props to the `ContactCard` instance in the footer.
- No changes were made to the social link rendering or the URL helper logic in `ContactCard`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eed0d054832f969bc039263d1b11)