### PR TITLE
Add Discord URL support to ContactCard

### DIFF
--- a/src/components/ContactCard.tsx
+++ b/src/components/ContactCard.tsx
@@ -24,12 +24,17 @@ export default function ContactCard({name, genre, location, tiktok, discord, you
       if (!val) return undefined;
       if (val.startsWith("http://") || val.startsWith("https://")) return val;
       if (kind === "tiktok") return `https://www.tiktok.com/@${val.replace(/^@/, "")}`;
+      if (kind === "discord") {
+        const normalized = val.trim();
+        if (/^\d+$/.test(normalized)) return `https://discord.com/users/${normalized}`;
+        return `https://discord.gg/${normalized}`;
+      }
       if (kind === "youtube") return `https://www.youtube.com/${val}`;
       if (kind === "soundcloud") return `https://www.soundcloud.com/${val}`;
       return val;
     };
     const tiktokUrl = toUrl(tiktok, "tiktok");
-    const discordUrl = toUrl(discord, "soundcloud");
+    const discordUrl = toUrl(discord, "discord");
     const youtubeUrl = toUrl(youtube, "youtube");
 
     return (


### PR DESCRIPTION
### Motivation
- Support Discord links in the contact card by interpreting stored Discord values as either numeric user IDs or invite codes.
- Fix the incorrect use of the `soundcloud` kind when building the Discord link so Discord entries are rendered correctly.
- Allow existing full URLs to pass through unchanged so explicit Discord URLs remain valid.

### Description
- Add a `discord` branch in `toUrl` that trims the input and returns `https://discord.com/users/<id>` when the value is numeric and `https://discord.gg/<code>` otherwise.
- Preserve values that already start with `http://` or `https://` inside the `toUrl` helper.
- Change `discordUrl` to call `toUrl(discord, "discord")` instead of using the `soundcloud` kind.
- Changes were made in `src/components/ContactCard.tsx` to implement the behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eebc4f10832f8ca22d0e61a9e1a8)